### PR TITLE
Bugfix, modal wasn't visible on screens > 480px

### DIFF
--- a/css/bootstrap-responsive.css
+++ b/css/bootstrap-responsive.css
@@ -124,7 +124,7 @@
     margin: 0;
   }
   .modal.fade.in {
-    top: auto;
+    top: 50%;
   }
   .modal-header .close {
     padding: 10px;


### PR DESCRIPTION
Just changed the top property of the modal in responsive mediaquery for screens below 480px. Now it works.

Checked in latest stable chrome for linux, chrome for android, and firefox for android.
