### PR TITLE
Added the nowrap attribute to the .box-header CSS classes.

### DIFF
--- a/css/charisma-app.css
+++ b/css/charisma-app.css
@@ -164,6 +164,7 @@ width:auto;
 clear:none;
 float:left;
 line-height:25px;
+white-space: nowrap;
 }
 .box-header h3{
 font-size:13px;
@@ -171,6 +172,7 @@ width:auto;
 clear:none;
 float:left;
 line-height:25px;
+white-space: nowrap;
 }
 .box-header h2 > i{
 margin-top:1px;


### PR DESCRIPTION
There were some short texts that got wrapped in the box title and hence a new
line was added in the title and it was not floating properly.
